### PR TITLE
Sec pprof

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,0 @@
-Version with Gorilla Framework
-Version with Iris Framework
-Add K8s
-Add jaeger
-Add Test structure

--- a/cmd/geo-api/main.go
+++ b/cmd/geo-api/main.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"expvar"
 	"log"
-	"net/http"
-	_ "net/http/pprof" // Register the pprof handlers
+	"net/http" // Register the pprof handlers
 	"os"
 	"os/signal"
 	"syscall"

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ fmt:
 	go fmt ./...
 
 lint:
-	golangci-lint run --modules-download-mode=vendor --timeout=2m0s -E golint --exclude-use-default=false --build-tags integration
+	golangci-lint run --modules-download-mode=vendor --timeout=2m0s  -E gosec -E revive --exclude-use-default=false --build-tags integration
 
 build:
 	CGO_ENABLED=0 GO111MODULE=on GOOS=linux go build -mod=vendor -a -installsuffix cgo -o ./bin/geo-api ./cmd/geo-api/main.go


### PR DESCRIPTION
- Update the deprecated golint with revive linter 
- Add gosec linter
- Remove the exposed endpoint debug/pprof